### PR TITLE
feat: set iterations to be twice of vus

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -245,6 +245,10 @@ func addVusAndIterationsArgs(args []string) []string {
 	iterations, err := getEnvInt64(HarborIterationsEnvKey)
 	mgx.Must(err)
 
+	if vus > 0 && iterations == 0 {
+		iterations = vus * 2
+	}
+
 	if vus > iterations {
 		mgx.Must(fmt.Errorf("the value of the %s must be less or equal with the value of %s", HarborVusEnvKey, HarborIterationsEnvKey))
 	}


### PR DESCRIPTION
Set iterations to be twice of vus when the vus provided but iterations
not provided.

Signed-off-by: He Weiwei <hweiwei@vmware.com>