### PR TITLE
refactor: make the setup of the tests simpler

### DIFF
--- a/scripts/test/list-audit-logs.js
+++ b/scripts/test/list-audit-logs.js
@@ -9,9 +9,8 @@ const settings = Settings()
 export let successRate = new Rate('success')
 
 export let options = {
-    setupTimeout: '24h',
-    teardownTimeout: '1h',
-    noUsageReport: true,
+    setupTimeout: '6h',
+    duration: '24h',
     vus: 500,
     iterations: 1000,
     thresholds: {

--- a/scripts/test/list-project-logs.js
+++ b/scripts/test/list-project-logs.js
@@ -1,17 +1,28 @@
 // test the performance for the list project logs API
+import { SharedArray } from 'k6/data'
 import { Rate } from 'k6/metrics'
 import harbor from 'k6/x/harbor'
 
 import { Settings } from '../config.js'
-import { fetchProjects, randomItem } from '../helpers.js'
+import { getProjectName, randomItem } from '../helpers.js'
 
 const settings = Settings()
+
+const projectNames = new SharedArray('projectNames', function () {
+    const results = []
+
+    for (let i = 0; i < settings.ProjectsCount; i++) {
+        results.push(getProjectName(settings, i))
+    }
+
+    return results
+});
 
 export let successRate = new Rate('success')
 
 export let options = {
-    setupTimeout: '24h',
-    teardownTimeout: '1h',
+    setupTimeout: '6h',
+    duration: '24h',
     noUsageReport: true,
     vus: 500,
     iterations: 1000,
@@ -25,19 +36,11 @@ export let options = {
 
 export function setup() {
     harbor.initialize(settings.Harbor)
-
-    const projects = fetchProjects(settings.ProjectsCount)
-
-    return {
-        projectNames: projects.map(p => p.name),
-    }
 }
 
-export default function ({ projectNames }) {
-    const projectName = randomItem(projectNames)
-
+export default function () {
     try {
-        harbor.listAuditLogsOfProject(projectName)
+        harbor.listAuditLogsOfProject(randomItem(projectNames))
         successRate.add(true)
     } catch (e) {
         successRate.add(false)

--- a/scripts/test/list-project-members.js
+++ b/scripts/test/list-project-members.js
@@ -1,18 +1,28 @@
 // test the performance for the list project members API
+import { SharedArray } from 'k6/data'
 import { Rate } from 'k6/metrics'
 import harbor from 'k6/x/harbor'
 
 import { Settings } from '../config.js'
-import { fetchProjects, randomItem } from '../helpers.js'
+import { getProjectName, randomItem } from '../helpers.js'
 
 const settings = Settings()
+
+const projectNames = new SharedArray('projectNames', function () {
+    const results = []
+
+    for (let i = 0; i < settings.ProjectsCount; i++) {
+        results.push(getProjectName(settings, i))
+    }
+
+    return results
+});
 
 export let successRate = new Rate('success')
 
 export let options = {
-    setupTimeout: '24h',
-    teardownTimeout: '1h',
-    noUsageReport: true,
+    setupTimeout: '6h',
+    duration: '24h',
     vus: 500,
     iterations: 1000,
     thresholds: {
@@ -25,19 +35,11 @@ export let options = {
 
 export function setup() {
     harbor.initialize(settings.Harbor)
-
-    const projects = fetchProjects(settings.ProjectsCount)
-
-    return {
-        projectNames: projects.map(p => p.name),
-    }
 }
 
-export default function ({ projectNames }) {
-    const projectName = randomItem(projectNames)
-
+export default function () {
     try {
-        harbor.listProjectMembers(projectName)
+        harbor.listProjectMembers(randomItem(projectNames))
         successRate.add(true)
     } catch (e) {
         successRate.add(false)

--- a/scripts/test/list-projects.js
+++ b/scripts/test/list-projects.js
@@ -9,9 +9,8 @@ const settings = Settings()
 export let successRate = new Rate('success')
 
 export let options = {
-    setupTimeout: '24h',
-    teardownTimeout: '1h',
-    noUsageReport: true,
+    setupTimeout: '6h',
+    duration: '24h',
     vus: 500,
     iterations: 1000,
     thresholds: {

--- a/scripts/test/list-quotas.js
+++ b/scripts/test/list-quotas.js
@@ -9,9 +9,8 @@ const settings = Settings()
 export let successRate = new Rate('success')
 
 export let options = {
-    setupTimeout: '24h',
-    teardownTimeout: '1h',
-    noUsageReport: true,
+    setupTimeout: '6h',
+    duration: '24h',
     vus: 500,
     iterations: 1000,
     thresholds: {

--- a/scripts/test/list-users.js
+++ b/scripts/test/list-users.js
@@ -9,9 +9,8 @@ const settings = Settings()
 export let successRate = new Rate('success')
 
 export let options = {
-    setupTimeout: '24h',
-    teardownTimeout: '1h',
-    noUsageReport: true,
+    setupTimeout: '6h',
+    duration: '24h',
     vus: 500,
     iterations: 1000,
     thresholds: {

--- a/scripts/test/search-users.js
+++ b/scripts/test/search-users.js
@@ -10,9 +10,8 @@ const settings = Settings()
 export let successRate = new Rate('success')
 
 export let options = {
-    setupTimeout: '24h',
-    teardownTimeout: '1h',
-    noUsageReport: true,
+    setupTimeout: '6h',
+    duration: '24h',
     vus: 500,
     iterations: 1000,
     thresholds: {


### PR DESCRIPTION
The project name, repository name and artifact tag are all fixable now,
so we don't need to query the harbor instance to get them in the
setup stage.

Signed-off-by: He Weiwei <hweiwei@vmware.com>