### PR TITLE
Draft: Update error handling on push artifact scripts

### DIFF
--- a/scripts/test/push-artifacts-to-different-projects.js
+++ b/scripts/test/push-artifacts-to-different-projects.js
@@ -63,7 +63,12 @@ export function teardown({ refs }) {
 
     for (const ref of refs) {
         const r = /([^/]+)\/([^:]+):(.*)/.exec(ref)
-        harbor.deleteArtifact(r[1], r[2], r[3])
+        
+        try {
+            harbor.deleteArtifact(r[1], r[2], r[3])
+        } catch (e) {
+            console.error(e.message)
+        }
     }
 }
 

--- a/scripts/test/push-artifacts-to-same-project.js
+++ b/scripts/test/push-artifacts-to-same-project.js
@@ -64,7 +64,12 @@ export function teardown({ refs }) {
 
     for (const ref of refs) {
         const r = /([^/]+)\/([^:]+):(.*)/.exec(ref)
-        harbor.deleteArtifact(r[1], r[2], r[3])
+
+        try {
+            harbor.deleteArtifact(r[1], r[2], r[3])
+        } catch (e) {
+            console.error(e.message)
+        }
     }
 }
 


### PR DESCRIPTION
This MR will add a simple try/catch to the deleteArtifact command in two of the tests.

If a artifact fails to push, then the scripts will still attempt to delete the artifact. This will cause the whole load test to fail instead of logging the error and continuing onto the next artifact. 